### PR TITLE
Published date is not set on direct publish

### DIFF
--- a/BrickPile.UI/Areas/UI/Controllers/PagesController.cs
+++ b/BrickPile.UI/Areas/UI/Controllers/PagesController.cs
@@ -244,7 +244,7 @@ namespace BrickPile.UI.Areas.UI.Controllers
 
             using (IDocumentSession session = this.documentStore.OpenSession())
             {
-                session.Store(pageModel, StoreAction.Save);
+                session.Store(pageModel, pageModel.Metadata.IsPublished ? StoreAction.Publish : StoreAction.Save);
 
                 if (parent != null)
                 {


### PR DESCRIPTION
When a page is created and published direct the publish date is not set
fixes #181