### PR TITLE
Add default sorting based on sortorder when loading ancestors in

### DIFF
--- a/BrickPile.Core/Routing/DefaultNavigationContextFactory.cs
+++ b/BrickPile.Core/Routing/DefaultNavigationContextFactory.cs
@@ -53,7 +53,7 @@ namespace BrickPile.Core.Routing
                 IPage[] pages = session.Load<IPage>(
                     this.routeResolverTrie.LoadTrie().GetAncestorIdsFor(
                         this.RequestContext.RouteData.GetCurrentPage<IPage>().Id,
-                        true));
+                        true)).OrderBy(x => x.Metadata.SortOrder).ToArray();
 
                 var navigationContext = new NavigationContext
                 {


### PR DESCRIPTION
`DefaultNavigationContextFactory`solves #183